### PR TITLE
fix on windows

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.3",
   "main": "lib/server.js",
   "scripts": {
-    "build": "./node_modules/babel-cli/bin/babel.js src --out-dir lib --plugins transform-react-jsx --presets es2015",
-    "bundle": "./node_modules/browserify/bin/cmd.js lib/client.js -o public/js/bundle.js",
-    "start": "npm run build && npm run bundle && node lib/server.js | ./node_modules/cypress/bin/cypress open"
+    "build": "babel src --out-dir lib --plugins transform-react-jsx --presets es2015",
+    "bundle": "browserify lib/client.js -o public/js/bundle.js",
+    "start": "npm run build && npm run bundle && node lib/server.js | cypress open"
   },
   "author": "Vance Lucas",
   "license": "MIT",

--- a/include-in-tests/autoMockCommands.js
+++ b/include-in-tests/autoMockCommands.js
@@ -43,7 +43,9 @@ function registerAutoMockCommands() {
     //currentMockFileName = testDirPath + '/../../automocks/' + sessionName;
 
     // get the absolute path for recording purposes
-    cy.exec('pwd', {
+    const pwd = Cypress.platform === 'win32' ? 'cd' : 'ls'
+    const ls = Cypress.platform === 'win32' ? 'dir ' : 'ls '
+    cy.exec(pwd, {
       log: false
     }).then(result => {
       const absolutePathToMockFile = result.stdout + '/cypress/automocks/' + sessionName;
@@ -51,7 +53,7 @@ function registerAutoMockCommands() {
       // if the config allows us to replay the mock, test if it exists
       if (automockPlayback) {
 
-        cy.exec('ls ' + absolutePathToMockFile, {
+        cy.exec(ls + absolutePathToMockFile, {
           failOnNonZeroExit: false,
           log: false
         }).then(result => {

--- a/include-in-tests/autoMockCommands.js
+++ b/include-in-tests/autoMockCommands.js
@@ -43,16 +43,15 @@ function registerAutoMockCommands() {
     //currentMockFileName = testDirPath + '/../../automocks/' + sessionName;
 
     // get the absolute path for recording purposes
-    const pwd = Cypress.platform === 'win32' ? 'cd' : 'ls'
+    const pwd = Cypress.platform === 'win32' ? 'cd' : 'pwd'
     const ls = Cypress.platform === 'win32' ? 'dir ' : 'ls '
     cy.exec(pwd, {
       log: false
     }).then(result => {
-      const absolutePathToMockFile = result.stdout + '/cypress/automocks/' + sessionName;
-
+      const mockFilePath = result.stdout + '/cypress/automocks/' + sessionName;
+      const absolutePathToMockFile = Cypress.platform === 'win32' ? mockFilePath.split('/').join('\\') : mockFilePath;
       // if the config allows us to replay the mock, test if it exists
       if (automockPlayback) {
-
         cy.exec(ls + absolutePathToMockFile, {
           failOnNonZeroExit: false,
           log: false


### PR DESCRIPTION
the following error appear when trying to use this plugin with cypress on windows:
![image](https://user-images.githubusercontent.com/10572734/50559401-6871e800-0cff-11e9-8491-3f770c198287.png)

The fix:

- [x] use `cd` instead of `pwd` for windows
- [x] use `dir` instead of `ls` for windows
- [x] replace all / with \ for the path to work in windows 