### PR TITLE
Fixed missing event listeners for XMLHttpRequest

### DIFF
--- a/include-in-webapp/installCypressHooks-norequire.js
+++ b/include-in-webapp/installCypressHooks-norequire.js
@@ -302,6 +302,14 @@
 
     overrideMimeType: function overrideMimeType(mimeType) {
       this.object.overrideMimeType(mimeType);
+    },
+
+    addEventListener: function(type, callback) {
+      this.object.addEventListener(type, callback);
+    },
+  
+    removeEventListener: function(type, callback) {
+      this.object.removeEventListener(type, callback);
     }
   };
   FakeXMLHttpRequest.prototype.constructor = FakeXMLHttpRequest;

--- a/include-in-webapp/installCypressHooks.js
+++ b/include-in-webapp/installCypressHooks.js
@@ -324,6 +324,14 @@ FakeXMLHttpRequest.prototype = {
 
   overrideMimeType: function (mimeType) {
     this.object.overrideMimeType(mimeType);
+  },
+
+  addEventListener: function(type, callback) {
+    this.object.addEventListener(type, callback);
+  },
+
+  removeEventListener: function(type, callback) {
+    this.object.removeEventListener(type, callback);
   }
 };
 FakeXMLHttpRequest.prototype.constructor = FakeXMLHttpRequest;


### PR DESCRIPTION
The changes in this PR fix this issue: https://github.com/scottschafer/cypressautomocker/issues/7